### PR TITLE
Cache git credentials to memory

### DIFF
--- a/Android-Flutter-Build.yaml
+++ b/Android-Flutter-Build.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_custom_script

--- a/Android-Flutter-Merge.yaml
+++ b/Android-Flutter-Merge.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_custom_script

--- a/Android-JavaKotlin-Build.yaml
+++ b/Android-JavaKotlin-Build.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_custom_script

--- a/Android-JavaKotlin-Merge.yaml
+++ b/Android-JavaKotlin-Merge.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_custom_script

--- a/Android-JavaKotlin-Metadata.yaml
+++ b/Android-JavaKotlin-Metadata.yaml
@@ -25,6 +25,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_metadata_android

--- a/Android-ReactNative-Build.yaml
+++ b/Android-ReactNative-Build.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: AC_REPOSITORY_DIR
 - componentType: appcircle_custom_script

--- a/Android-ReactNative-Merge.yaml
+++ b/Android-ReactNative-Merge.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: AC_REPOSITORY_DIR
 - componentType: appcircle_custom_script

--- a/Android-ReactNative-Metadata.yaml
+++ b/Android-ReactNative-Metadata.yaml
@@ -25,6 +25,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_metadata_android

--- a/Android-Smartface-Build.yaml
+++ b/Android-Smartface-Build.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_npm_yarn

--- a/Android-Smartface-Merge.yaml
+++ b/Android-Smartface-Merge.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_npm_yarn

--- a/iOS-Flutter-Build.yaml
+++ b/iOS-Flutter-Build.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_custom_script

--- a/iOS-Flutter-Merge.yaml
+++ b/iOS-Flutter-Merge.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_custom_script

--- a/iOS-Flutter-Metadata.yaml
+++ b/iOS-Flutter-Metadata.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_metadata_ios

--- a/iOS-ObjectiveCSwift-Build.yaml
+++ b/iOS-ObjectiveCSwift-Build.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_custom_script

--- a/iOS-ObjectiveCSwift-Merge.yaml
+++ b/iOS-ObjectiveCSwift-Merge.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_custom_script

--- a/iOS-ObjectiveCSwift-Metadata.yaml
+++ b/iOS-ObjectiveCSwift-Metadata.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_metadata_ios

--- a/iOS-ReactNative-Build.yaml
+++ b/iOS-ReactNative-Build.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_custom_script

--- a/iOS-ReactNative-Merge.yaml
+++ b/iOS-ReactNative-Merge.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_custom_script

--- a/iOS-ReactNative-Metadata.yaml
+++ b/iOS-ReactNative-Metadata.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_metadata_ios

--- a/iOS-Smartface-Build.yaml
+++ b/iOS-Smartface-Build.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_npm_yarn

--- a/iOS-Smartface-Merge.yaml
+++ b/iOS-Smartface-Merge.yaml
@@ -28,6 +28,7 @@ steps:
   - AC_GIT_LFS: "false"
   - AC_GIT_BRANCH: "$AC_GIT_BRANCH"
   - AC_GIT_COMMIT: "$AC_GIT_COMMIT"
+  - AC_GIT_CACHE_CREDENTIALS: "true"
   outputs:
   - AC_REPOSITORY_DIR: "AC_REPOSITORY_DIR"
 - componentType: appcircle_npm_yarn


### PR DESCRIPTION
Cache credentials are saved to memory[^1]. This can be useful if the same credentials are used for private dependencies. This behavior can be disabled from the settings of the [Git Clone](https://github.com/appcircleio/appcircle-git-clone-component) component.

[^1]: [git-credential-cache](https://git-scm.com/docs/git-credential-cache)