### PR TITLE
Fix commit id for Android Meta Data

### DIFF
--- a/Android-JavaKotlin-Metadata.yaml
+++ b/Android-JavaKotlin-Metadata.yaml
@@ -19,7 +19,7 @@ steps:
   stepName: Git
   webUrl: https://github.com/appcircleio/appcircle-git-clone-component
   repoUrl: https://github.com/appcircleio/appcircle-git-clone-component.git
-  commit: 6343567
+  commit: eabcfab
   inputs:
   - AC_GIT_URL: "$AC_GIT_URL"
   - AC_GIT_LFS: "false"


### PR DESCRIPTION
- [x] Changed commit id to the new version. The fetch details button selects the version with the commit id, it doesn't update to the new version automatically.